### PR TITLE
feat(data): SQLite species cache with TTL and common names

### DIFF
--- a/lib/features/fish_scanner/data/species_cache_db.dart
+++ b/lib/features/fish_scanner/data/species_cache_db.dart
@@ -22,7 +22,7 @@ class SpeciesCacheDb {
   static const String _createSpeciesCache = '''
     CREATE TABLE species_cache (
       scientific_name TEXT PRIMARY KEY,
-      sw_rating       TEXT NOT NULL,
+      seafood_watch_rating TEXT NOT NULL,
       fishbase_code   INTEGER,
       fetched_at      INTEGER NOT NULL,
       expires_at      INTEGER NOT NULL
@@ -44,6 +44,7 @@ class SpeciesCacheDb {
   /// `getApplicationDocumentsDirectory()/ecopal.db`.
   /// Pass [inMemoryDatabasePath] from `sqflite_common_ffi` for testing.
   Future<void> init({String? dbPath}) async {
+    if (_db != null) return;
     final resolvedPath = dbPath ?? await _defaultDbPath();
     _db = await openDatabase(
       resolvedPath,
@@ -96,7 +97,7 @@ class SpeciesCacheDb {
 
     return SpeciesInfo(
       scientificName: scientificName,
-      rating: _parseRating(row['sw_rating'] as String),
+      rating: _parseRating(row['seafood_watch_rating'] as String),
       commonNames: commonNames,
       fishbaseCode: row['fishbase_code'] as int?,
     );
@@ -134,7 +135,7 @@ class SpeciesCacheDb {
       'species_cache',
       {
         'scientific_name': species.scientificName,
-        'sw_rating': species.rating.name,
+        'seafood_watch_rating': species.rating.name,
         'fishbase_code': species.fishbaseCode,
         'fetched_at': fetchedAt,
         'expires_at': expiresAt,


### PR DESCRIPTION
## Summary
Implements the SQLite species cache DAO for issue #15.

## Changes
- **lib/features/fish_scanner/data/species_cache_db.dart** — SpeciesCacheDb singleton with:
  - init({String? dbPath}) — opens/creates copal.db in app documents dir (injectable for tests)
  - lookup(scientificName, languageCode) — cache-first; returns null on miss or TTL expiry
  - store(species) — upserts species_cache + common_names rows
  - clearExpired() — deletes rows where xpires_at < now()
  - _parseRating(value) — string → SeafoodWatchRating enum
  - storeWithTimestamps() @visibleForTesting for precise expiry control in tests
- **	est/features/fish_scanner/data/species_cache_db_test.dart** — 4 tests using sqflite_common_ffi in-memory DB:
  - store → lookup returns correct data
  - lookup returns null on cache miss
  - expired TTL returns null
  - clearExpired removes only expired rows

## Checklist
- [x] No raw SQL string interpolation (all parameterised)
- [x] Cache TTL: 7 days (604800 seconds)
- [x] \lutter analyze\ — zero warnings
- [x] All public methods have doc comments
- [x] All 4 tests pass

Closes #15