### PR TITLE
feat(data): OSPAR/HELCOM regional species adapter (CC BY)

### DIFF
--- a/assets/data/helcom_species.json
+++ b/assets/data/helcom_species.json
@@ -1,5 +1,3 @@
-// CC BY — HELCOM Red List of Baltic Sea species in danger of becoming extinct.
-// Source: https://helcom.fi/baltic-sea-trends/biodiversity/red-list-of-species/
 [
   {"scientific_name": "Acipenser oxyrinchus", "status": "red_listed", "region": "Baltic Sea"},
   {"scientific_name": "Anguilla anguilla", "status": "red_listed", "region": "Baltic Sea"},

--- a/assets/data/ospar_species.json
+++ b/assets/data/ospar_species.json
@@ -1,5 +1,3 @@
-// CC BY — OSPAR Commission, Quality Status Report & Threatened/Declining Species lists.
-// Source: https://www.ospar.org/work-areas/bdc/species-habitats/list-of-threatened-declining-species-habitats
 [
   {"scientific_name": "Gadus morhua", "status": "threatened", "region": "NE Atlantic"},
   {"scientific_name": "Anguilla anguilla", "status": "threatened", "region": "NE Atlantic"},

--- a/lib/features/fish_scanner/adapters/regional_adapter.dart
+++ b/lib/features/fish_scanner/adapters/regional_adapter.dart
@@ -1,7 +1,23 @@
+// Data sources (CC BY):
+// - OSPAR Commission Threatened & Declining Species list
+//   https://www.ospar.org/work-areas/bdc/species-habitats/list-of-threatened-declining-species-habitats
+// - HELCOM Red List of Baltic Sea species
+//   https://helcom.fi/baltic-sea-trends/biodiversity/red-list-of-species/
+
 import 'dart:convert';
 import 'package:flutter/services.dart';
 
-enum RegionalStatus { osparThreatened, helcomRedListed, notListed }
+enum RegionalStatus {
+  osparThreatened,
+  helcomRedListed,
+  notListed;
+
+  String get i18nKey => switch (this) {
+    RegionalStatus.osparThreatened => 'regionalBadgeOsparThreatened',
+    RegionalStatus.helcomRedListed => 'regionalBadgeHelcomRedListed',
+    RegionalStatus.notListed       => 'regionalBadgeNotListed',
+  };
+}
 
 class RegionalAdapter {
   final _ospar = <String>{};

--- a/test/features/fish_scanner/adapters/regional_adapter_test.dart
+++ b/test/features/fish_scanner/adapters/regional_adapter_test.dart
@@ -63,4 +63,10 @@ void main() {
     // Gadus morhua appears in both OSPAR and HELCOM lists; OSPAR takes priority
     expect(adapter.getStatus('Gadus morhua'), RegionalStatus.osparThreatened);
   });
+
+  test('RegionalStatus.i18nKey returns correct keys', () {
+    expect(RegionalStatus.osparThreatened.i18nKey, 'regionalBadgeOsparThreatened');
+    expect(RegionalStatus.helcomRedListed.i18nKey, 'regionalBadgeHelcomRedListed');
+    expect(RegionalStatus.notListed.i18nKey, 'regionalBadgeNotListed');
+  });
 }


### PR DESCRIPTION
## Summary

Implements Issue #20 — OSPAR/HELCOM regional species adapter.

### Changes
- **ssets/data/ospar_species.json** — 20 NE Atlantic threatened species (CC BY, OSPAR Commission)
- **ssets/data/helcom_species.json** — 20 Baltic Sea red-listed species (CC BY, HELCOM)
- **lib/features/fish_scanner/adapters/regional_adapter.dart** — \RegionalAdapter\ with \RegionalStatus\ enum; \init()\ loads JSON from \ootBundle\; \getStatus()\ synchronous lookup with OSPAR priority
- **	est/features/fish_scanner/adapters/regional_adapter_test.dart** — 4 tests covering all status paths

### Verification
- \lutter analyze --fatal-warnings --no-pub\: ✅ No issues
- All 4 tests pass ✅

Closes #20