### PR TITLE
feat(#21): Scanner UI — camera preview, overlay stack, RatingBadge, SpeciesInfoCard

### DIFF
--- a/lib/features/fish_scanner/screens/fish_scanner_screen.dart
+++ b/lib/features/fish_scanner/screens/fish_scanner_screen.dart
@@ -2,12 +2,24 @@ import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
 
+import '../models/detection_result.dart';
 import '../services/camera_service.dart';
+import '../services/frame_processor.dart';
+import '../widgets/species_info_card.dart';
 
 /// Main Fish Scanner screen.
-/// Hosts the camera preview and overlay stack.
+///
+/// Displays a full-bleed [CameraPreview] with a transparent overlay [Stack]
+/// for bounding boxes (painted in Issue #22) and a bottom info panel showing
+/// the detected species name, common name, and rating badge.
+///
+/// Manages camera lifecycle through [WidgetsBindingObserver]: pauses the image
+/// stream when the app is backgrounded and resumes it on foreground.
 class FishScannerScreen extends StatefulWidget {
-  const FishScannerScreen({super.key});
+  const FishScannerScreen({super.key, CameraService? cameraService})
+      : _cameraService = cameraService;
+
+  final CameraService? _cameraService;
 
   @override
   State<FishScannerScreen> createState() => _FishScannerScreenState();
@@ -15,14 +27,32 @@ class FishScannerScreen extends StatefulWidget {
 
 class _FishScannerScreenState extends State<FishScannerScreen>
     with WidgetsBindingObserver {
-  final CameraService _cameraService = CameraService();
+  late final CameraService _cameraService;
+  late final FrameProcessor _frameProcessor;
   late final Future<void> _initFuture;
+
+  /// Stub detection result shown in the bottom info panel.
+  /// TODO(#22): replace with live [DetectionResult] from ML pipeline.
+  static const SpeciesInfo _stubSpecies = SpeciesInfo(
+    scientificName: 'Thunnus thynnus',
+    rating: SeafoodWatchRating.avoid,
+    commonNames: {'en': 'Atlantic Bluefin Tuna'},
+  );
 
   @override
   void initState() {
     super.initState();
+    _cameraService = widget._cameraService ?? CameraService();
+    _frameProcessor = FrameProcessor();
     WidgetsBinding.instance.addObserver(this);
-    _initFuture = _cameraService.initialize();
+    _initFuture = _initCamera();
+  }
+
+  Future<void> _initCamera() async {
+    await _cameraService.initialize();
+    if (_cameraService.errorMessage.value == null) {
+      _frameProcessor.start(_cameraService.imageStream);
+    }
     _cameraService.errorMessage.addListener(_onCameraError);
   }
 
@@ -31,9 +61,13 @@ class _FishScannerScreenState extends State<FishScannerScreen>
     switch (state) {
       case AppLifecycleState.paused:
       case AppLifecycleState.inactive:
+        _frameProcessor.stop();
         _cameraService.stopImageStream();
       case AppLifecycleState.resumed:
         _cameraService.startImageStream();
+        if (_cameraService.controller?.value.isInitialized ?? false) {
+          _frameProcessor.start(_cameraService.imageStream);
+        }
       default:
         break;
     }
@@ -60,24 +94,28 @@ class _FishScannerScreenState extends State<FishScannerScreen>
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     _cameraService.errorMessage.removeListener(_onCameraError);
+    _frameProcessor.dispose();
     _cameraService.dispose();
     super.dispose();
   }
+
+  // ── UI ──────────────────────────────────────────────────────────────────
 
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
 
     return Scaffold(
-      backgroundColor: colorScheme.surface,
+      backgroundColor: Colors.black,
+      extendBodyBehindAppBar: true,
       appBar: AppBar(
         backgroundColor: Colors.transparent,
         elevation: 0,
-        title: Text(
-          // TODO(#27): replace with AppLocalizations.of(context)!.scannerTitle
+        title: const Text(
+          // TODO(#27): AppLocalizations.of(context)!.appTitle
           'ecopal',
           style: TextStyle(
-            color: colorScheme.onSurface,
+            color: Colors.white,
             fontWeight: FontWeight.bold,
           ),
         ),
@@ -85,14 +123,16 @@ class _FishScannerScreenState extends State<FishScannerScreen>
           IconButton(
             // TODO(#27): AppLocalizations — switch camera tooltip
             tooltip: 'Switch camera',
-            icon: Icon(Icons.flip_camera_android, color: colorScheme.onSurface),
+            icon: const Icon(Icons.flip_camera_android, color: Colors.white),
             onPressed: () async {
               await _cameraService.switchCamera();
               if (mounted) setState(() {});
             },
           ),
           IconButton(
-            icon: Icon(Icons.settings, color: colorScheme.onSurface),
+            // TODO(#27): AppLocalizations — settings tooltip
+            tooltip: 'Settings',
+            icon: const Icon(Icons.settings, color: Colors.white),
             onPressed: () {
               // Settings screen — future issue
             },
@@ -103,77 +143,187 @@ class _FishScannerScreenState extends State<FishScannerScreen>
         future: _initFuture,
         builder: (context, snapshot) {
           if (snapshot.connectionState != ConnectionState.done) {
-            return Center(
-              child: CircularProgressIndicator(color: colorScheme.primary),
-            );
+            return _LoadingView(colorScheme: colorScheme);
           }
 
           final error = _cameraService.errorMessage.value;
           if (error != null) {
-            return Center(
-              child: Padding(
-                padding: const EdgeInsets.all(24),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(
-                      Icons.no_photography,
-                      size: 64,
-                      color: colorScheme.onSurface.withAlpha(128),
-                    ),
-                    const SizedBox(height: 16),
-                    Text(
-                      // TODO(#27): AppLocalizations — camera error heading
-                      'Camera unavailable',
-                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                            color: colorScheme.onSurface,
-                          ),
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      error,
-                      textAlign: TextAlign.center,
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                            color: colorScheme.onSurface.withAlpha(179),
-                          ),
-                    ),
-                    const SizedBox(height: 16),
-                    FilledButton.icon(
-                      onPressed: openAppSettings,
-                      icon: const Icon(Icons.settings),
-                      // TODO(#27): AppLocalizations — open settings button
-                      label: const Text('Open Settings'),
-                    ),
-                  ],
-                ),
-              ),
+            return _ErrorView(
+              error: error,
+              colorScheme: colorScheme,
+              onRetry: _onRetry,
             );
           }
 
           final controller = _cameraService.controller;
           if (controller == null || !controller.value.isInitialized) {
-            return Center(
-              child: CircularProgressIndicator(color: colorScheme.primary),
-            );
+            return _LoadingView(colorScheme: colorScheme);
           }
 
-          return AnimatedBuilder(
-            animation: _cameraService.errorMessage,
-            builder: (context, _) {
-              final liveError = _cameraService.errorMessage.value;
-              if (liveError != null) {
-                return Center(
-                  child: Text(
-                    liveError,
-                    style: TextStyle(color: colorScheme.error),
-                  ),
-                );
-              }
-              return CameraPreview(_cameraService.controller!);
-            },
+          return _ScannerView(
+            controller: controller,
+            stubSpecies: _stubSpecies,
+            errorMessage: _cameraService.errorMessage,
+            colorScheme: colorScheme,
           );
         },
       ),
+    );
+  }
+
+  Future<void> _onRetry() async {
+    setState(() {});
+    await _cameraService.initialize();
+    if (_cameraService.errorMessage.value == null) {
+      _frameProcessor.start(_cameraService.imageStream);
+    }
+  }
+}
+
+// ── Private sub-widgets ──────────────────────────────────────────────────────
+
+class _LoadingView extends StatelessWidget {
+  const _LoadingView({required this.colorScheme});
+
+  final ColorScheme colorScheme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: CircularProgressIndicator(color: colorScheme.primary),
+    );
+  }
+}
+
+/// Shown when camera initialisation fails (permission denied or hardware error).
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({
+    required this.error,
+    required this.colorScheme,
+    required this.onRetry,
+  });
+
+  final String error;
+  final ColorScheme colorScheme;
+  final VoidCallback onRetry;
+
+  static const _permissionDeniedSubstring = 'permission';
+
+  @override
+  Widget build(BuildContext context) {
+    final isPermissionError =
+        error.toLowerCase().contains(_permissionDeniedSubstring);
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              isPermissionError ? Icons.no_photography : Icons.error_outline,
+              size: 64,
+              color: colorScheme.onSurface.withAlpha(128),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              // TODO(#27): AppLocalizations — camera error heading
+              isPermissionError ? 'Camera permission denied' : 'Camera unavailable',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: colorScheme.onSurface,
+                  ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              error,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onSurface.withAlpha(179),
+                  ),
+            ),
+            const SizedBox(height: 16),
+            if (isPermissionError)
+              FilledButton.icon(
+                onPressed: openAppSettings,
+                icon: const Icon(Icons.settings),
+                // TODO(#27): AppLocalizations — open settings button
+                label: const Text('Open Settings'),
+              )
+            else
+              FilledButton.icon(
+                onPressed: onRetry,
+                icon: const Icon(Icons.refresh),
+                // TODO(#27): AppLocalizations — retry button
+                label: const Text('Retry'),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// The camera preview + overlay stack shown when the camera is ready.
+class _ScannerView extends StatelessWidget {
+  const _ScannerView({
+    required this.controller,
+    required this.stubSpecies,
+    required this.errorMessage,
+    required this.colorScheme,
+  });
+
+  final CameraController controller;
+
+  /// Stub species info shown until Issue #22 wires real detections.
+  /// TODO(#22): replace with a stream of live [DetectionResult]s.
+  final SpeciesInfo stubSpecies;
+
+  final ValueNotifier<String?> errorMessage;
+  final ColorScheme colorScheme;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: errorMessage,
+      builder: (context, _) {
+        final liveError = errorMessage.value;
+        if (liveError != null) {
+          return Center(
+            child: Text(
+              liveError,
+              style: TextStyle(color: colorScheme.error),
+            ),
+          );
+        }
+
+        return Stack(
+          fit: StackFit.expand,
+          children: [
+            // Layer 1 — full-bleed camera preview.
+            CameraPreview(controller),
+
+            // Layer 2 — bounding box overlay (painter implemented in Issue #22).
+            // TODO(#22): replace with FishOverlayPainter CustomPaint widget.
+            IgnorePointer(
+              child: Container(color: Colors.transparent),
+            ),
+
+            // Layer 3 — bottom info panel.
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: 0,
+              child: SafeArea(
+                top: false,
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+                  child: SpeciesInfoCard(speciesInfo: stubSpecies),
+                ),
+              ),
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/features/fish_scanner/widgets/rating_badge.dart
+++ b/lib/features/fish_scanner/widgets/rating_badge.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+import '../models/detection_result.dart';
+
+/// A compact coloured pill badge displaying a [SeafoodWatchRating].
+///
+/// Uses the exact Seafood Watch colour palette. Suitable for use
+/// beside bounding boxes and within info cards.
+class RatingBadge extends StatelessWidget {
+  const RatingBadge({
+    super.key,
+    required this.rating,
+  });
+
+  final SeafoodWatchRating rating;
+
+  @override
+  Widget build(BuildContext context) {
+    final colour = rating.colour;
+    final icon = rating.icon;
+    // TODO(#27): AppLocalizations — rating label
+    final label = rating.label;
+
+    return Semantics(
+      label: 'Seafood Watch rating: $label',
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+        decoration: BoxDecoration(
+          color: colour,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              icon,
+              style: const TextStyle(fontSize: 12),
+            ),
+            const SizedBox(width: 4),
+            Text(
+              label,
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 11,
+                fontWeight: FontWeight.bold,
+                letterSpacing: 0.5,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/fish_scanner/widgets/species_info_card.dart
+++ b/lib/features/fish_scanner/widgets/species_info_card.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+import '../models/detection_result.dart';
+import 'rating_badge.dart';
+
+/// A semi-transparent card overlay that shows species information on the
+/// scanner screen.
+///
+/// Displays the scientific name, English common name (from
+/// [SpeciesInfo.commonNames]) and a [RatingBadge]. Designed to be readable
+/// on top of a live camera feed.
+class SpeciesInfoCard extends StatelessWidget {
+  const SpeciesInfoCard({
+    super.key,
+    required this.speciesInfo,
+  });
+
+  final SpeciesInfo speciesInfo;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    // TODO(#27): AppLocalizations — use device locale for common name lookup
+    final commonName =
+        speciesInfo.commonNames['en'] ?? speciesInfo.scientificName;
+
+    return Semantics(
+      label: 'Species: ${speciesInfo.scientificName}, '
+          'common name: $commonName, '
+          'rating: ${speciesInfo.rating.label}',
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        decoration: BoxDecoration(
+          color: Colors.black.withAlpha(178),
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              speciesInfo.scientificName,
+              style: textTheme.bodySmall?.copyWith(
+                color: Colors.white70,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+            const SizedBox(height: 2),
+            Text(
+              commonName,
+              style: textTheme.titleMedium?.copyWith(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 8),
+            RatingBadge(rating: speciesInfo.rating),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/fish_scanner/screens/fish_scanner_screen_test.dart
+++ b/test/features/fish_scanner/screens/fish_scanner_screen_test.dart
@@ -1,0 +1,64 @@
+import 'package:ecopal/features/fish_scanner/screens/fish_scanner_screen.dart';
+import 'package:ecopal/features/fish_scanner/services/camera_service.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+/// A [CameraService] that immediately reports a permission denied error,
+/// so the scanner screen can be tested without real hardware.
+class _PermissionDeniedCameraService extends CameraService {
+  _PermissionDeniedCameraService()
+      : super(
+          cameras: const [],
+          permissionRequester: () async => PermissionStatus.denied,
+        );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('FishScannerScreen builds without error', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: FishScannerScreen(
+          cameraService: _PermissionDeniedCameraService(),
+        ),
+      ),
+    );
+
+    // Initial frame — FutureBuilder has not resolved yet.
+    expect(find.byType(FishScannerScreen), findsOneWidget);
+  });
+
+  testWidgets('FishScannerScreen shows loading indicator initially',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: FishScannerScreen(
+          cameraService: _PermissionDeniedCameraService(),
+        ),
+      ),
+    );
+
+    // Before the future completes the loading spinner must be visible.
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets(
+      'FishScannerScreen shows permission denied error after init completes',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: FishScannerScreen(
+          cameraService: _PermissionDeniedCameraService(),
+        ),
+      ),
+    );
+
+    // Settle all async work (initialize + FutureBuilder).
+    await tester.pumpAndSettle();
+
+    expect(find.text('Camera permission denied'), findsWidgets);
+    expect(find.text('Open Settings'), findsOneWidget);
+  });
+}

--- a/test/features/fish_scanner/widgets/rating_badge_test.dart
+++ b/test/features/fish_scanner/widgets/rating_badge_test.dart
@@ -1,0 +1,49 @@
+import 'package:ecopal/features/fish_scanner/models/detection_result.dart';
+import 'package:ecopal/features/fish_scanner/widgets/rating_badge.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Widget wrap(Widget child) =>
+      MaterialApp(home: Scaffold(body: Center(child: child)));
+
+  group('RatingBadge', () {
+    for (final entry in {
+      SeafoodWatchRating.bestChoice: const Color(0xFF4CAF50),
+      SeafoodWatchRating.goodAlternative: const Color(0xFFFFC107),
+      SeafoodWatchRating.avoid: const Color(0xFFF44336),
+      SeafoodWatchRating.notRated: const Color(0xFF9E9E9E),
+    }.entries) {
+      testWidgets('renders correct colour for ${entry.key.name}',
+          (tester) async {
+    await tester.pumpWidget(wrap(RatingBadge(rating: entry.key)));
+
+        final container = tester.widget<Container>(
+          find.descendant(
+            of: find.byType(RatingBadge),
+            matching: find.byType(Container),
+          ),
+        );
+        final decoration = container.decoration as BoxDecoration;
+        expect(decoration.color, entry.value);
+      });
+    }
+
+    testWidgets('shows label text', (tester) async {
+      await tester.pumpWidget(
+        wrap(const RatingBadge(rating: SeafoodWatchRating.avoid)),
+      );
+      expect(find.text('AVOID'), findsOneWidget);
+    });
+
+    testWidgets('has Semantics wrapper with label', (tester) async {
+      await tester.pumpWidget(
+        wrap(const RatingBadge(rating: SeafoodWatchRating.bestChoice)),
+      );
+      expect(
+        find.bySemanticsLabel(RegExp(r'Seafood Watch rating')),
+        findsOneWidget,
+      );
+    });
+  });
+}

--- a/test/features/fish_scanner/widgets/species_info_card_test.dart
+++ b/test/features/fish_scanner/widgets/species_info_card_test.dart
@@ -1,0 +1,60 @@
+import 'package:ecopal/features/fish_scanner/models/detection_result.dart';
+import 'package:ecopal/features/fish_scanner/widgets/species_info_card.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Widget wrap(Widget child) =>
+      MaterialApp(home: Scaffold(body: Center(child: child)));
+
+  const species = SpeciesInfo(
+    scientificName: 'Gadus morhua',
+    rating: SeafoodWatchRating.goodAlternative,
+    commonNames: {'en': 'Atlantic Cod'},
+  );
+
+  group('SpeciesInfoCard', () {
+    testWidgets('displays scientific name', (tester) async {
+      await tester.pumpWidget(wrap(const SpeciesInfoCard(speciesInfo: species)));
+      expect(find.text('Gadus morhua'), findsOneWidget);
+    });
+
+    testWidgets('displays English common name', (tester) async {
+      await tester.pumpWidget(wrap(const SpeciesInfoCard(speciesInfo: species)));
+      expect(find.text('Atlantic Cod'), findsOneWidget);
+    });
+
+    testWidgets('falls back to scientific name when no en common name',
+        (tester) async {
+      const noEn = SpeciesInfo(
+        scientificName: 'Thunnus albacares',
+        rating: SeafoodWatchRating.notRated,
+        commonNames: {'pt': 'Atum Amarelo'},
+      );
+      await tester.pumpWidget(wrap(const SpeciesInfoCard(speciesInfo: noEn)));
+      // scientific name shown as fallback for both scientific and common name slots
+      expect(find.text('Thunnus albacares'), findsWidgets);
+    });
+
+    testWidgets('contains a RatingBadge', (tester) async {
+      await tester.pumpWidget(wrap(const SpeciesInfoCard(speciesInfo: species)));
+      expect(find.byType(SpeciesInfoCard), findsOneWidget);
+      // RatingBadge must be a descendant
+      expect(
+        find.descendant(
+          of: find.byType(SpeciesInfoCard),
+          matching: find.text('GOOD ALTERNATIVE'),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('has Semantics wrapper', (tester) async {
+      await tester.pumpWidget(wrap(const SpeciesInfoCard(speciesInfo: species)));
+      expect(
+        find.bySemanticsLabel(RegExp(r'Species: Gadus morhua')),
+        findsOneWidget,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What changed

Implements Issue #21 — the Fish Scanner screen UI shell.

### New files
- \lib/features/fish_scanner/widgets/rating_badge.dart\ — coloured pill badge for each \SeafoodWatchRating\; uses exact Seafood Watch hex colours; \Semantics\ wrapper for accessibility.
- \lib/features/fish_scanner/widgets/species_info_card.dart\ — semi-transparent dark overlay card showing scientific name, English common name, and \RatingBadge\; proper semantics.

### Updated
- \lib/features/fish_scanner/screens/fish_scanner_screen.dart\ — full implementation replacing the TODO scaffold:
  - Full-bleed \CameraPreview\ as base layer
  - \FrameProcessor\ wired to the camera image stream
  - Transparent overlay \Stack\ placeholder (TODO #22 for \FishOverlayPainter\)
  - Bottom \SpeciesInfoCard\ panel with stub species data (TODO #22 for live detections)
  - Loading state, error state with retry button, permission-denied state with Settings button
  - \WidgetsBindingObserver\ pauses/resumes camera on app background/foreground
  - \CameraService\ injected via constructor for testability

### Tests (new)
- \ating_badge_test.dart\ — colour per rating, label text, semantics
- \species_info_card_test.dart\ — scientific name, common name, badge presence, semantics
- \ish_scanner_screen_test.dart\ — builds without error, loading state, permission-denied state (mock \CameraService\)

## How to test

1. Run \lutter test --no-pub\ — all 75 tests pass.
2. Run \lutter analyze --fatal-warnings --no-pub\ — 0 issues.
3. On a physical device: the scanner screen shows the live camera feed with the stub species card at the bottom.

Closes #21