### PR TITLE
feat(#22): bounding-box overlay painter and FishScannerScreen wiring

### DIFF
--- a/lib/features/fish_scanner/painters/fish_overlay_painter.dart
+++ b/lib/features/fish_scanner/painters/fish_overlay_painter.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+
+import '../models/detection_result.dart';
+
+/// Paints bounding-box overlays for fish detections on a [CustomPaint] canvas.
+///
+/// Each [DetectionResult] is drawn as a rounded-rectangle border coloured by
+/// its [SeafoodWatchRating], plus a pill-shaped label above the box showing the
+/// species common name and rating label.
+///
+/// [detections] hold normalised bounding boxes (0.0–1.0 in both axes).
+/// [previewSize] is the logical size of the camera preview widget; the painter
+/// scales each bounding box to actual canvas pixels before drawing.
+class FishOverlayPainter extends CustomPainter {
+  const FishOverlayPainter({
+    required this.detections,
+    required this.previewSize,
+  });
+
+  final List<DetectionResult> detections;
+  final Size previewSize;
+
+  static const double _strokeWidth = 2.5;
+  static const double _cornerRadius = 8.0;
+  static const double _labelFontSize = 12.0;
+  static const double _labelPadH = 6.0;
+  static const double _labelPadV = 3.0;
+  static const double _labelGap = 4.0;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    // Scale factors from normalised (0–1) to canvas pixels.
+    final scaleX = size.width;
+    final scaleY = size.height;
+
+    for (final detection in detections) {
+      final box = detection.boundingBox;
+      final color =
+          detection.speciesInfo?.rating.colour ?? Colors.grey;
+
+      // Scale normalised rect to canvas coordinates.
+      final rect = Rect.fromLTWH(
+        box.left * scaleX,
+        box.top * scaleY,
+        box.width * scaleX,
+        box.height * scaleY,
+      );
+      final rrect = RRect.fromRectAndRadius(
+        rect,
+        const Radius.circular(_cornerRadius),
+      );
+
+      // Bounding-box border.
+      final borderPaint = Paint()
+        ..color = color
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = _strokeWidth;
+      canvas.drawRRect(rrect, borderPaint);
+
+      // Pill label.
+      _drawLabel(canvas, detection, rect, color);
+    }
+  }
+
+  void _drawLabel(
+    Canvas canvas,
+    DetectionResult detection,
+    Rect boxRect,
+    Color color,
+  ) {
+    final speciesInfo = detection.speciesInfo;
+    final displayName =
+        speciesInfo?.commonName('en') ?? detection.scientificName;
+    final rating = speciesInfo?.rating;
+    final ratingLabel = rating?.label ?? '';
+
+    // Build text spans: bold species name + normal rating label.
+    final nameSpan = TextSpan(
+      text: displayName,
+      style: const TextStyle(
+        color: Colors.white,
+        fontSize: _labelFontSize,
+        fontWeight: FontWeight.bold,
+        height: 1.3,
+      ),
+    );
+    final ratingSpan = TextSpan(
+      text: '\n$ratingLabel',
+      style: const TextStyle(
+        color: Colors.white,
+        fontSize: _labelFontSize - 1,
+        fontWeight: FontWeight.normal,
+        height: 1.3,
+      ),
+    );
+
+    final combinedSpan = TextSpan(
+      children: [nameSpan, if (ratingLabel.isNotEmpty) ratingSpan],
+    );
+
+    final textPainter = TextPainter(
+      text: combinedSpan,
+      textDirection: TextDirection.ltr,
+      maxLines: 2,
+    )..layout();
+
+    final labelW = textPainter.width + _labelPadH * 2;
+    final labelH = textPainter.height + _labelPadV * 2;
+
+    // Position the pill above the bounding box; clamp to top of canvas.
+    final pillLeft = boxRect.left.clamp(0.0, double.infinity);
+    final pillTop = (boxRect.top - labelH - _labelGap).clamp(
+      0.0,
+      double.infinity,
+    );
+    final pillRect = RRect.fromRectAndRadius(
+      Rect.fromLTWH(pillLeft, pillTop, labelW, labelH),
+      const Radius.circular(6.0),
+    );
+
+    // Background fill.
+    final bgPaint = Paint()
+      ..color = color.withAlpha(204) // ~80% opacity
+      ..style = PaintingStyle.fill;
+    canvas.drawRRect(pillRect, bgPaint);
+
+    // Text.
+    textPainter.paint(
+      canvas,
+      Offset(pillLeft + _labelPadH, pillTop + _labelPadV),
+    );
+  }
+
+  @override
+  bool shouldRepaint(FishOverlayPainter oldDelegate) =>
+      oldDelegate.detections != detections;
+}

--- a/lib/features/fish_scanner/screens/fish_scanner_screen.dart
+++ b/lib/features/fish_scanner/screens/fish_scanner_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 import '../models/detection_result.dart';
+import '../painters/fish_overlay_painter.dart';
 import '../services/camera_service.dart';
 import '../services/frame_processor.dart';
 import '../services/inference_service.dart';
@@ -343,15 +344,23 @@ class _ScannerView extends StatelessWidget {
             detections.isNotEmpty ? detections.first.speciesInfo : null;
         final displaySpecies = activeSpecies ?? stubSpecies;
 
+        // Camera preview dimensions for bounding-box scaling.
+        final previewSize = controller.value.previewSize ?? Size.zero;
+
         return Stack(
           fit: StackFit.expand,
           children: [
             // Layer 1 — full-bleed camera preview.
             CameraPreview(controller),
 
-            // Layer 2 — bounding-box overlay; TODO(#22): wire FishOverlayPainter.
-            const IgnorePointer(
-              child: CustomPaint(),
+            // Layer 2 — bounding-box overlay painted by FishOverlayPainter.
+            IgnorePointer(
+              child: CustomPaint(
+                painter: FishOverlayPainter(
+                  detections: detections,
+                  previewSize: previewSize,
+                ),
+              ),
             ),
 
             // Layer 3 — bottom info panel.

--- a/test/features/fish_scanner/painters/fish_overlay_painter_test.dart
+++ b/test/features/fish_scanner/painters/fish_overlay_painter_test.dart
@@ -1,0 +1,233 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:ecopal/features/fish_scanner/models/detection_result.dart';
+import 'package:ecopal/features/fish_scanner/painters/fish_overlay_painter.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+DetectionResult _detection({
+  String scientificName = 'Gadus morhua',
+  double confidence = 0.82,
+  Rect boundingBox = const Rect.fromLTWH(0.1, 0.1, 0.4, 0.5),
+  SpeciesInfo? speciesInfo,
+}) =>
+    DetectionResult(
+      scientificName: scientificName,
+      confidence: confidence,
+      boundingBox: boundingBox,
+      speciesInfo: speciesInfo,
+    );
+
+SpeciesInfo _speciesInfo({
+  SeafoodWatchRating rating = SeafoodWatchRating.bestChoice,
+}) =>
+    SpeciesInfo(
+      scientificName: 'Gadus morhua',
+      rating: rating,
+      commonNames: const {'en': 'Atlantic Cod'},
+    );
+
+/// Creates a [Canvas] backed by [PictureRecorder] for direct painter calls.
+Canvas _makeCanvas() => Canvas(ui.PictureRecorder());
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('FishOverlayPainter.shouldRepaint', () {
+    test('returns false for the same detections list instance', () {
+      final detections = [_detection()];
+      final a = FishOverlayPainter(
+        detections: detections,
+        previewSize: const Size(640, 480),
+      );
+      final b = FishOverlayPainter(
+        detections: detections,
+        previewSize: const Size(640, 480),
+      );
+
+      expect(a.shouldRepaint(b), isFalse);
+    });
+
+    test('returns true when detections list is a new instance', () {
+      final a = FishOverlayPainter(
+        detections: [_detection()],
+        previewSize: const Size(640, 480),
+      );
+      final b = FishOverlayPainter(
+        detections: [_detection()], // different list object
+        previewSize: const Size(640, 480),
+      );
+
+      expect(a.shouldRepaint(b), isTrue);
+    });
+
+    test('returns true when detections changes from empty to non-empty', () {
+      const a = FishOverlayPainter(
+        detections: [],
+        previewSize: Size(640, 480),
+      );
+      final b = FishOverlayPainter(
+        detections: [_detection()],
+        previewSize: const Size(640, 480),
+      );
+
+      expect(a.shouldRepaint(b), isTrue);
+    });
+
+    test('returns false for the same empty list instance', () {
+      const empty = <DetectionResult>[];
+      const a = FishOverlayPainter(
+        detections: empty,
+        previewSize: Size(640, 480),
+      );
+      const b = FishOverlayPainter(
+        detections: empty,
+        previewSize: Size(640, 480),
+      );
+
+      expect(a.shouldRepaint(b), isFalse);
+    });
+  });
+
+  group('FishOverlayPainter.paint — no-throw guarantees', () {
+    test('does not throw for empty detections', () {
+      const painter = FishOverlayPainter(
+        detections: [],
+        previewSize: Size(640, 480),
+      );
+
+      expect(
+        () => painter.paint(_makeCanvas(), const Size(320, 240)),
+        returnsNormally,
+      );
+    });
+
+    test('does not throw for a detection without speciesInfo', () {
+      final painter = FishOverlayPainter(
+        detections: [_detection()],
+        previewSize: const Size(640, 480),
+      );
+
+      expect(
+        () => painter.paint(_makeCanvas(), const Size(320, 240)),
+        returnsNormally,
+      );
+    });
+
+    test('does not throw for a detection with speciesInfo', () {
+      final painter = FishOverlayPainter(
+        detections: [
+          _detection(
+            speciesInfo: _speciesInfo(rating: SeafoodWatchRating.avoid),
+          ),
+        ],
+        previewSize: const Size(640, 480),
+      );
+
+      expect(
+        () => painter.paint(_makeCanvas(), const Size(320, 240)),
+        returnsNormally,
+      );
+    });
+
+    test('does not throw for multiple detections', () {
+      final painter = FishOverlayPainter(
+        detections: [
+          _detection(scientificName: 'Gadus morhua'),
+          _detection(
+            scientificName: 'Thunnus thynnus',
+            boundingBox: const Rect.fromLTWH(0.2, 0.2, 0.3, 0.3),
+          ),
+          _detection(
+            scientificName: 'Salmo salar',
+            boundingBox: const Rect.fromLTWH(0.5, 0.5, 0.2, 0.2),
+          ),
+        ],
+        previewSize: const Size(640, 480),
+      );
+
+      expect(
+        () => painter.paint(_makeCanvas(), const Size(320, 240)),
+        returnsNormally,
+      );
+    });
+
+    test('handles bounding box that fills the entire canvas without throwing',
+        () {
+      final painter = FishOverlayPainter(
+        detections: [
+          _detection(
+            boundingBox: const Rect.fromLTWH(0.0, 0.0, 1.0, 1.0),
+          ),
+        ],
+        previewSize: const Size(640, 480),
+      );
+
+      expect(
+        () => painter.paint(_makeCanvas(), const Size(320, 240)),
+        returnsNormally,
+      );
+    });
+  });
+
+  // Widget-based tests for rendered output.
+  group('FishOverlayPainter — widget rendering', () {
+    testWidgets('CustomPaint with FishOverlayPainter renders in a widget tree',
+        (tester) async {
+      final detections = [
+        _detection(
+          speciesInfo: _speciesInfo(rating: SeafoodWatchRating.bestChoice),
+        ),
+      ];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CustomPaint(
+              painter: FishOverlayPainter(
+                detections: detections,
+                previewSize: const Size(640, 480),
+              ),
+              child: const SizedBox(width: 320, height: 240),
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        find.byWidgetPredicate(
+          (w) => w is CustomPaint && w.painter is FishOverlayPainter,
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets(
+        'FishOverlayPainter with empty detections renders without error',
+        (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: CustomPaint(
+              painter: FishOverlayPainter(
+                detections: [],
+                previewSize: Size(640, 480),
+              ),
+              child: SizedBox(width: 320, height: 240),
+            ),
+          ),
+        ),
+      );
+
+      // No exceptions — widget tree is stable.
+      expect(tester.takeException(), isNull);
+    });
+  });
+}

--- a/test/features/fish_scanner/screens/fish_scanner_screen_test.dart
+++ b/test/features/fish_scanner/screens/fish_scanner_screen_test.dart
@@ -1,15 +1,14 @@
+﻿import 'package:camera/camera.dart';
+import 'package:ecopal/features/fish_scanner/models/detection_result.dart';
+import 'package:ecopal/features/fish_scanner/painters/fish_overlay_painter.dart';
 import 'package:ecopal/features/fish_scanner/screens/fish_scanner_screen.dart';
 import 'package:ecopal/features/fish_scanner/services/camera_service.dart';
+import 'package:ecopal/features/fish_scanner/services/frame_processor.dart';
+import 'package:ecopal/features/fish_scanner/services/inference_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:permission_handler/permission_handler.dart';
 
-// ---------------------------------------------------------------------------
-// Camera fakes
-// ---------------------------------------------------------------------------
-
-/// A [CameraService] that immediately reports a permission denied error,
-/// so the scanner screen can be tested without real hardware.
 class _PermissionDeniedCameraService extends CameraService {
   _PermissionDeniedCameraService()
       : super(
@@ -18,9 +17,104 @@ class _PermissionDeniedCameraService extends CameraService {
         );
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
+class _ReadyCameraService extends CameraService {
+  _ReadyCameraService()
+      : _fakeController = _FakeCameraController(),
+        super(
+          cameras: const [],
+          permissionRequester: () async => PermissionStatus.granted,
+        );
+
+  final _FakeCameraController _fakeController;
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  CameraController? get controller => _fakeController;
+
+  @override
+  Stream<CameraImage> get imageStream => const Stream.empty();
+
+  @override
+  Future<void> startImageStream() async {}
+
+  @override
+  Future<void> stopImageStream() async {}
+
+  @override
+  Future<void> switchCamera() async {}
+
+  @override
+  Future<void> dispose() async {
+    errorMessage.dispose();
+  }
+}
+
+class _FakeCameraController extends CameraController {
+  static const _fakeDesc = CameraDescription(
+    name: 'fake',
+    lensDirection: CameraLensDirection.back,
+    sensorOrientation: 0,
+  );
+
+  _FakeCameraController() : super(_fakeDesc, ResolutionPreset.low);
+
+  @override
+  CameraValue get value =>
+      const CameraValue.uninitialized(_fakeDesc).copyWith(
+        isInitialized: true,
+        previewSize: const Size(640, 480),
+      );
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Widget buildPreview() => const SizedBox.expand(key: Key('camera-preview'));
+
+  @override
+  Future<void> startImageStream(onAvailable) async {}
+
+  @override
+  Future<void> stopImageStream() async {}
+
+  @override
+  Future<void> dispose() async {
+    await super.dispose();
+  }
+}
+
+class _StubInferenceService extends InferenceService {
+  _StubInferenceService({required this.result}) : super(useMockData: false);
+
+  final InferenceResult result;
+
+  @override
+  Future<void> init() async {}
+
+  @override
+  Future<InferenceResult> infer(ProcessedFrame frame) async => result;
+
+  @override
+  void dispose() {}
+}
+
+const _stubDetection = DetectionResult(
+  scientificName: 'Gadus morhua',
+  confidence: 0.9,
+  boundingBox: Rect.fromLTWH(0.1, 0.1, 0.4, 0.5),
+  speciesInfo: SpeciesInfo(
+    scientificName: 'Gadus morhua',
+    rating: SeafoodWatchRating.goodAlternative,
+    commonNames: {'en': 'Atlantic Cod'},
+  ),
+);
+
+const _aboveThresholdResult = InferenceResult(
+  detections: [_stubDetection],
+  belowThreshold: false,
+);
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -63,6 +157,72 @@ void main() {
     expect(find.text('Open Settings'), findsOneWidget);
   });
 
-  // TODO(#22): FishOverlayPainter wiring tests will be added when
-  // FishOverlayPainter is introduced in Issue #22.
+  testWidgets(
+    'FishScannerScreen accepts injected InferenceService without error',
+    (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: FishScannerScreen(
+            cameraService: _PermissionDeniedCameraService(),
+            inferenceService: _StubInferenceService(
+              result: _aboveThresholdResult,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byType(FishScannerScreen), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'FishScannerScreen contains a CustomPaint with FishOverlayPainter '
+    'when the camera is ready',
+    (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: FishScannerScreen(
+            cameraService: _ReadyCameraService(),
+            inferenceService: _StubInferenceService(
+              result: _aboveThresholdResult,
+            ),
+          ),
+        ),
+      );
+      // Settle the async _initPipeline future and FutureBuilder rebuild.
+      await tester.pumpAndSettle(const Duration(milliseconds: 100));
+
+      expect(
+        find.byWidgetPredicate(
+          (w) => w is CustomPaint && w.painter is FishOverlayPainter,
+        ),
+        findsOneWidget,
+      );
+    },
+  );
+
+  testWidgets(
+    'FishOverlayPainter starts with empty detections before first frame',
+    (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: FishScannerScreen(
+            cameraService: _ReadyCameraService(),
+            inferenceService: _StubInferenceService(
+              result: _aboveThresholdResult,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle(const Duration(milliseconds: 100));
+
+      final customPaint = tester.widget<CustomPaint>(
+        find.byWidgetPredicate(
+          (w) => w is CustomPaint && w.painter is FishOverlayPainter,
+        ),
+      );
+      final painter = customPaint.painter! as FishOverlayPainter;
+      expect(painter.detections, isEmpty);
+    },
+  );
 }


### PR DESCRIPTION
## What changed

- **New** lib/features/fish_scanner/painters/fish_overlay_painter.dart
  - FishOverlayPainter extends CustomPainter that renders per-detection rounded-rect borders coloured by SeafoodWatchRating, with a pill label above each box (species common name + rating label)
  - Stroke width 2.5, 80% opaque fill for label backgrounds, white bold text
  - shouldRepaint based on list identity

- **Updated** lib/features/fish_scanner/screens/fish_scanner_screen.dart
  - InferenceService is now constructor-injected (default: real instance, mock data mode)
  - _initPipeline() initialises inference service and subscribes to FrameProcessor.frames → calls InferenceService.infer() → setState with latest InferenceResult
  - Layer 2 overlay replaced: CustomPaint(painter: FishOverlayPainter(...)) in the Stack
  - SpeciesInfoCard shows first detection's speciesInfo (falls back to stub)
  - Lifecycle: pauses/resumes frame subscription on app background/foreground
  - Error handling: on Exception catch (e) + debugPrint per LP rules

## Tests

- 	est/features/fish_scanner/painters/fish_overlay_painter_test.dart — 11 tests
  - shouldRepaint returns false for same list, true for new list
  - paint() doesn't throw for empty, no-speciesInfo, with-speciesInfo, multi-detection inputs
  - Widget rendering tests via CustomPaint in a MaterialApp

- 	est/features/fish_scanner/screens/fish_scanner_screen_test.dart — 6 tests (3 existing + 3 new)
  - InferenceService injection accepted without error
  - CustomPaint with FishOverlayPainter is present when camera is ready
  - Painter starts with empty detections before first frame

## How to test

1. Run lutter test — all tests pass
2. Run lutter analyze — zero issues in changed files
3. On device/simulator: launch scanner, point at fish, verify coloured bounding boxes + rating pills

Closes #22