### PR TITLE
feat(#14): CloudFallbackService - iNaturalist cloud identification fallback

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -266,6 +266,27 @@ git push "https://$token@github.com/ruimcoder/ecopal.git" BRANCH:BRANCH
 Never store the token in the remote URL permanently — use it only for the one-off push command.  
 **Applies to:** All git push operations in automated/Copilot shell sessions.
 
+
+### LP-005 — 15-second timeout on all cloud API calls (PR #14, 2025)
+**Context:** Cloud fallback calls (e.g. iNaturalist) must not block the UI indefinitely on slow networks.
+**Rule:** Chain `.timeout(const Duration(seconds: 15))` on every outbound HTTP call. Catch `TimeoutException` explicitly *before* the generic `on Exception catch (e)` handler so it can be logged distinctly. Never use `catch (_)`.
+```dart
+await client.send(request).timeout(const Duration(seconds: 15));
+// ...
+} on TimeoutException catch (e) {
+  debugPrint('...: request timed out — $e');
+  return null;
+} on Exception catch (e) {
+  debugPrint('...: request failed — $e');
+  return null;
+}
+```
+**Applies to:** All HTTP calls to external APIs (iNaturalist, Seafood Watch, CITES, etc.).
+
+### LP-006 — No `//` comments inside JSON (PR #48, 2025)
+**Context:** A seed data file contained `//` comments inside a JSON body, causing parse errors at runtime.
+**Rule:** JSON does not support comments. Never include `//` or `/* */` comments anywhere inside a JSON file or a JSON string literal. Use a companion `.md` or a `_comment` key if annotation is needed.
+**Applies to:** All `.json` files, inline `jsonEncode(...)` calls, and HTTP response fixtures in tests.
 ---
 
 ## Key Reminders

--- a/lib/features/fish_scanner/services/cloud_fallback_service.dart
+++ b/lib/features/fish_scanner/services/cloud_fallback_service.dart
@@ -1,0 +1,204 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+import '../data/species_cache_db.dart';
+import '../models/detection_result.dart';
+import 'consent_service.dart';
+
+/// iNaturalist Computer Vision API endpoint.
+const String _kInatUrl =
+    'https://api.inaturalist.org/v1/computervision/score_image';
+
+/// HTTP timeout for the iNaturalist API call (LP-005).
+const Duration _kTimeout = Duration(seconds: 15);
+
+/// Scientific name used for the hardcoded mock result.
+const String _kMockScientificName = 'Thunnus obesus';
+
+/// Common name used for the hardcoded mock result.
+const String _kMockCommonName = 'Bigeye Tuna';
+
+/// Sends [frameBytes] to the iNaturalist API and returns the raw JSON body.
+///
+/// Returns `null` on network failure, timeout, or a non-200 status.
+///
+/// TODO(#30): add certificate pinning before production rollout.
+Future<String?> _defaultSendFrame(Uint8List frameBytes) async {
+  final client = http.Client();
+  try {
+    final request = http.MultipartRequest('POST', Uri.parse(_kInatUrl))
+      ..files.add(
+        http.MultipartFile.fromBytes(
+          'image',
+          frameBytes,
+          filename: 'frame.jpg',
+        ),
+      );
+    final streamed =
+        await client.send(request).timeout(_kTimeout); // LP-005
+    final response = await http.Response.fromStream(streamed);
+    if (response.statusCode != 200) {
+      debugPrint(
+        'CloudFallbackService: iNaturalist returned ${response.statusCode}',
+      );
+      return null;
+    }
+    return response.body;
+  } on TimeoutException catch (e) {
+    debugPrint('CloudFallbackService: request timed out — $e');
+    return null;
+  } on Exception catch (e) {
+    debugPrint('CloudFallbackService: request failed — $e');
+    return null;
+  } finally {
+    client.close();
+  }
+}
+
+/// Identifies fish species via the iNaturalist Computer Vision API when
+/// on-device inference confidence falls below threshold.
+///
+/// **Consent gate:** [identify] checks [ConsentService.requestConsentIfNeeded]
+/// before any frame is transmitted. If consent is not granted the method
+/// returns `null` immediately and no data leaves the device.
+///
+/// **Mock mode** (`useMockData = true`, the default): skips the HTTP call and
+/// returns a hardcoded [DetectionResult] for [_kMockScientificName]. Use this
+/// during development and in unit tests that do not need to exercise HTTP.
+///
+/// **Real mode** (`useMockData = false`): delegates the HTTP POST to
+/// [sendFrameFn] (defaults to [_defaultSendFrame]), which sends [frameBytes]
+/// to the iNaturalist Computer Vision API with a [_kTimeout] timeout.
+/// The top taxon suggestion is parsed and cached in [SpeciesCacheDb].
+///
+/// The returned [DetectionResult] always has [DetectionResult.boundingBox] set
+/// to [Rect.zero] — the caller is responsible for supplying the real box from
+/// the original detection pipeline.
+///
+/// TODO(#30): add certificate pinning to iNaturalist calls before
+/// production rollout — see [_defaultSendFrame].
+class CloudFallbackService {
+  CloudFallbackService({
+    required this.consentService,
+    required this.cacheDb,
+    bool useMockData = true,
+    Future<String?> Function(Uint8List)? sendFrameFn,
+  })  : _useMockData = useMockData,
+        _sendFrameFn = sendFrameFn ?? _defaultSendFrame;
+
+  final ConsentService consentService;
+  final SpeciesCacheDb cacheDb;
+  final bool _useMockData;
+  final Future<String?> Function(Uint8List) _sendFrameFn;
+
+  /// Attempts to identify a fish species from [frameBytes] using the
+  /// iNaturalist Computer Vision API.
+  ///
+  /// Returns a [DetectionResult] on success, or `null` when:
+  /// - the user has not granted cloud fallback consent, or
+  /// - mock mode is disabled and the HTTP call fails or times out, or
+  /// - the API response contains no usable taxon suggestion.
+  Future<DetectionResult?> identify(
+    Uint8List frameBytes,
+    BuildContext context,
+  ) async {
+    final granted = await consentService.requestConsentIfNeeded(context);
+    if (!granted) return null;
+
+    if (_useMockData) return _mockResult();
+
+    return _fetchFromInat(frameBytes);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /// Returns a hardcoded [DetectionResult] for [_kMockScientificName].
+  Future<DetectionResult?> _mockResult() async {
+    const speciesInfo = SpeciesInfo(
+      scientificName: _kMockScientificName,
+      rating: SeafoodWatchRating.notRated,
+      commonNames: {'en': _kMockCommonName},
+    );
+    await cacheDb.store(speciesInfo);
+    return const DetectionResult(
+      scientificName: _kMockScientificName,
+      confidence: 1.0,
+      boundingBox: Rect.zero,
+      speciesInfo: speciesInfo,
+    );
+  }
+
+  /// Calls [_sendFrameFn] and parses the response.
+  ///
+  /// Returns `null` if [_sendFrameFn] returns null (it handles its own
+  /// error logging) or if the response cannot be parsed.
+  Future<DetectionResult?> _fetchFromInat(Uint8List frameBytes) async {
+    try {
+      final body = await _sendFrameFn(frameBytes);
+      if (body == null) return null;
+      return _parseResponse(body);
+    } on TimeoutException catch (e) {
+      debugPrint('CloudFallbackService: request timed out — $e');
+      return null;
+    } on Exception catch (e) {
+      debugPrint('CloudFallbackService: request failed — $e');
+      return null;
+    }
+  }
+
+  /// Parses the iNaturalist Computer Vision response body.
+  ///
+  /// Extracts the top suggestion's [taxon.name] (scientific name) and [score]
+  /// (confidence), stores the result in [cacheDb], and wraps it in a
+  /// [DetectionResult].
+  Future<DetectionResult?> _parseResponse(String body) async {
+    try {
+      final decoded = jsonDecode(body) as Map<String, dynamic>;
+      final results = decoded['results'] as List<dynamic>?;
+
+      if (results == null || results.isEmpty) {
+        debugPrint('CloudFallbackService: no results in iNaturalist response');
+        return null;
+      }
+
+      final top = results.first as Map<String, dynamic>;
+      final taxon = top['taxon'] as Map<String, dynamic>?;
+      final score = (top['score'] as num?)?.toDouble();
+
+      if (taxon == null || score == null) {
+        debugPrint('CloudFallbackService: missing taxon or score in response');
+        return null;
+      }
+
+      final scientificName = taxon['name'] as String?;
+      if (scientificName == null || scientificName.isEmpty) {
+        debugPrint('CloudFallbackService: empty scientific name in response');
+        return null;
+      }
+
+      final speciesInfo = SpeciesInfo(
+        scientificName: scientificName,
+        rating: SeafoodWatchRating.notRated,
+        commonNames: const {},
+      );
+
+      await cacheDb.store(speciesInfo);
+
+      return DetectionResult(
+        scientificName: scientificName,
+        confidence: score,
+        boundingBox: Rect.zero,
+        speciesInfo: speciesInfo,
+      );
+    } on Exception catch (e) {
+      debugPrint('CloudFallbackService: failed to parse response — $e');
+      return null;
+    }
+  }
+}

--- a/test/features/fish_scanner/services/cloud_fallback_service_test.dart
+++ b/test/features/fish_scanner/services/cloud_fallback_service_test.dart
@@ -1,0 +1,229 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:ecopal/features/fish_scanner/data/species_cache_db.dart';
+import 'package:ecopal/features/fish_scanner/models/detection_result.dart';
+import 'package:ecopal/features/fish_scanner/services/cloud_fallback_service.dart';
+import 'package:ecopal/features/fish_scanner/services/consent_service.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+/// Fake [ConsentService] that returns [grantResult] immediately without
+/// showing a dialog or touching SharedPreferences.
+class _FakeConsentService extends ConsentService {
+  _FakeConsentService({
+    required this.grantResult,
+    required SharedPreferences prefs,
+  }) : super(prefs);
+
+  final bool grantResult;
+
+  @override
+  Future<bool> requestConsentIfNeeded(BuildContext context) async => grantResult;
+}
+
+/// Minimal iNaturalist-shaped JSON response with a single top result.
+String _inatResponse({required String scientificName, required double score}) {
+  return jsonEncode({
+    'total_results': 1,
+    'results': [
+      {
+        'score': score,
+        'taxon': {
+          'name': scientificName,
+          'iconic_taxon_name': 'Actinopterygii',
+        },
+      },
+    ],
+  });
+}
+
+/// A minimal non-empty byte payload (tiny JPEG header bytes).
+final Uint8List _stubFrame = Uint8List.fromList([0xFF, 0xD8, 0xFF]);
+
+/// Pumps a minimal widget tree and returns a real [BuildContext] for tests
+/// whose [_FakeConsentService] ignores the context entirely.
+Future<BuildContext> _buildContext(WidgetTester tester) async {
+  await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+  return tester.element(find.byType(SizedBox));
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SpeciesCacheDb.instance.init(dbPath: inMemoryDatabasePath);
+  });
+
+  tearDown(() async {
+    await SpeciesCacheDb.instance.close();
+  });
+
+  group('CloudFallbackService', () {
+    // -------------------------------------------------------------------------
+    // Consent gate
+    // -------------------------------------------------------------------------
+
+    testWidgets('returns null immediately when consent is not granted',
+        (tester) async {
+      final ctx = await _buildContext(tester);
+      final prefs = await SharedPreferences.getInstance();
+      var sendCalled = false;
+      final svc = CloudFallbackService(
+        consentService: _FakeConsentService(grantResult: false, prefs: prefs),
+        cacheDb: SpeciesCacheDb.instance,
+        useMockData: false,
+        sendFrameFn: (_) async {
+          sendCalled = true;
+          return '{}';
+        },
+      );
+
+      final result = await tester.runAsync(() => svc.identify(_stubFrame, ctx));
+
+      expect(result, isNull, reason: 'no frame should be sent without consent');
+      expect(sendCalled, isFalse);
+    });
+
+    // -------------------------------------------------------------------------
+    // Mock mode
+    // -------------------------------------------------------------------------
+
+    testWidgets('mock mode returns Thunnus obesus without calling sendFrameFn',
+        (tester) async {
+      final ctx = await _buildContext(tester);
+      final prefs = await SharedPreferences.getInstance();
+      var sendCalled = false;
+      final svc = CloudFallbackService(
+        consentService: _FakeConsentService(grantResult: true, prefs: prefs),
+        cacheDb: SpeciesCacheDb.instance,
+        useMockData: true,
+        sendFrameFn: (_) async {
+          sendCalled = true;
+          return '{}';
+        },
+      );
+
+      final result = await tester.runAsync(() => svc.identify(_stubFrame, ctx));
+
+      expect(result, isNotNull);
+      expect(result!.scientificName, equals('Thunnus obesus'));
+      expect(result.boundingBox, equals(Rect.zero));
+      expect(result.speciesInfo, isNotNull);
+      expect(sendCalled, isFalse, reason: 'mock mode must never call sendFrameFn');
+    });
+
+    // -------------------------------------------------------------------------
+    // HTTP failure
+    // -------------------------------------------------------------------------
+
+    testWidgets('returns null gracefully when sendFrameFn throws an exception',
+        (tester) async {
+      final ctx = await _buildContext(tester);
+      final prefs = await SharedPreferences.getInstance();
+      final svc = CloudFallbackService(
+        consentService: _FakeConsentService(grantResult: true, prefs: prefs),
+        cacheDb: SpeciesCacheDb.instance,
+        useMockData: false,
+        sendFrameFn: (_) async => throw Exception('Network failure'),
+      );
+
+      final result = await tester.runAsync(() => svc.identify(_stubFrame, ctx));
+
+      expect(result, isNull);
+    });
+
+    // -------------------------------------------------------------------------
+    // Timeout (LP-005)
+    // -------------------------------------------------------------------------
+
+    testWidgets('returns null gracefully on TimeoutException (LP-005)',
+        (tester) async {
+      final ctx = await _buildContext(tester);
+      final prefs = await SharedPreferences.getInstance();
+      final svc = CloudFallbackService(
+        consentService: _FakeConsentService(grantResult: true, prefs: prefs),
+        cacheDb: SpeciesCacheDb.instance,
+        useMockData: false,
+        sendFrameFn: (_) async => throw TimeoutException(
+          'simulated 15s timeout',
+          const Duration(seconds: 15),
+        ),
+      );
+
+      final result = await tester.runAsync(() => svc.identify(_stubFrame, ctx));
+
+      expect(result, isNull);
+    });
+
+    // -------------------------------------------------------------------------
+    // Caching — entire body in runAsync so sqflite Futures complete in the
+    // real event loop (not the testWidgets fake-async zone).
+    // -------------------------------------------------------------------------
+
+    testWidgets(
+        'caches result in SpeciesCacheDb after successful identification',
+        (tester) async {
+      final ctx = await _buildContext(tester);
+
+      await tester.runAsync(() async {
+        const scientificName = 'Gadus morhua';
+        const score = 0.92;
+
+        final prefs = await SharedPreferences.getInstance();
+        final svc = CloudFallbackService(
+          consentService: _FakeConsentService(grantResult: true, prefs: prefs),
+          cacheDb: SpeciesCacheDb.instance,
+          useMockData: false,
+          sendFrameFn: (_) async =>
+              _inatResponse(scientificName: scientificName, score: score),
+        );
+
+        final result = await svc.identify(_stubFrame, ctx);
+
+        expect(result, isNotNull);
+        expect(result!.scientificName, equals(scientificName));
+        expect(result.confidence, equals(score));
+        expect(result.boundingBox, equals(Rect.zero));
+        expect(result.speciesInfo!.rating, equals(SeafoodWatchRating.notRated));
+
+        final cached =
+            await SpeciesCacheDb.instance.lookup(scientificName, 'en');
+        expect(cached, isNotNull, reason: 'result must be written to cache');
+        expect(cached!.scientificName, equals(scientificName));
+        expect(cached.rating, equals(SeafoodWatchRating.notRated));
+      });
+    });
+
+    testWidgets('mock mode result is also cached in SpeciesCacheDb',
+        (tester) async {
+      final ctx = await _buildContext(tester);
+
+      await tester.runAsync(() async {
+        final prefs = await SharedPreferences.getInstance();
+        final svc = CloudFallbackService(
+          consentService: _FakeConsentService(grantResult: true, prefs: prefs),
+          cacheDb: SpeciesCacheDb.instance,
+          useMockData: true,
+        );
+
+        final result = await svc.identify(_stubFrame, ctx);
+
+        expect(result, isNotNull);
+
+        final cached =
+            await SpeciesCacheDb.instance.lookup('Thunnus obesus', 'en');
+        expect(cached, isNotNull, reason: 'mock result must also be cached');
+      });
+    });
+  });
+}


### PR DESCRIPTION
## What changed

Implements CloudFallbackService in lib/features/fish_scanner/services/cloud_fallback_service.dart.

### Service behaviour
- **Consent gate first**: calls ConsentService.requestConsentIfNeeded(context) before any frame leaves the device. Returns null immediately if not granted.
- **Mock mode** (useMockData = true, default): returns a hardcoded DetectionResult for Thunnus obesus (Bigeye Tuna) - no network required, demonstrates the fallback flow during development.
- **Real mode**: delegates the HTTP POST to _defaultSendFrame which sends frame bytes as multipart to https://api.inaturalist.org/v1/computervision/score_image with a 15-second timeout (LP-005).
- Parses top taxon name (scientific) and score (confidence) from the iNaturalist response.
- Caches every result in SpeciesCacheDb with SeafoodWatchRating.notRated as placeholder (SeafoodWatch adapter enriches it later).
- Returns DetectionResult with boundingBox: Rect.zero - caller fills real box from the detection pipeline.
- Error handling: on TimeoutException catch (e) + on Exception catch (e) + debugPrint - no silent failures, no catch(_).
- TODO(#30): cert pinning comment on the HTTP call.

### Learned Patterns added to .github/copilot-instructions.md
- **LP-005**: .timeout(const Duration(seconds: 15)) on HTTP calls + on TimeoutException catch
- **LP-006**: No // comments inside JSON

## How to test

1. In mock mode (default): instantiate CloudFallbackService and call identify() - returns Bigeye Tuna result immediately, no network.
2. flutter test test/features/fish_scanner/services/cloud_fallback_service_test.dart - 6 tests covering consent gate, mock mode, HTTP failure, timeout, and caching.
3. flutter analyze - zero issues.

Closes #14
